### PR TITLE
Updated Alpine Version to make python3 & pip3 work

### DIFF
--- a/nzedb/Dockerfile
+++ b/nzedb/Dockerfile
@@ -3,7 +3,7 @@
 # Create a quick and clean dev environment
 #
 
-FROM alpine:3.3
+FROM alpine:3.6
 MAINTAINER razorgirl <https://github.com/razorgirl>
 
 # Set correct environment variables.


### PR DESCRIPTION
Your version of alpine is old, and there is a bug in that old version with pip3. Updating alpinelinux to the newest branch resolves this.